### PR TITLE
Enforce minimal md-toc version to fix requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d883fcccf82d14a964043fb67a10aef3f39aee88fa48d2ef89b644ead00ab77a
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -25,7 +25,7 @@ requirements:
     - boto3
     - isort >=5.6.4,<6.0.0
     - jinja2 >=2.10.3,<3.0.0
-    - md-toc
+    - md-toc >=7.2.0  # Older versions of md-toc seem to lead to inconsistent requirements.
     - mdformat >=0.7.5,<0.8.0
     - pip
     - pyparsing >=2.4.7,<3.0.0


### PR DESCRIPTION
I was getting the following error on `pip check`:
```
md-toc 7.0.2 has requirement fpyutils==1.1.2, but you have fpyutils 2.0.0.
```